### PR TITLE
Fix example summaries

### DIFF
--- a/src/public/v1/components/examples.yaml
+++ b/src/public/v1/components/examples.yaml
@@ -209,7 +209,7 @@ components:
           "links": { }
         }
     npmVersionMetadataTree:
-      summary: 'structure: true'
+      summary: 'structure: tree'
       value:
         {
           "type": "npm",
@@ -267,7 +267,7 @@ components:
           }
         }
     npmVersionMetadataScopedTree:
-      summary: 'structure: true'
+      summary: 'structure: tree'
       value:
         {
           "type": "npm",


### PR DESCRIPTION
Fix typo by changing `true` to `tree`.

![image](https://github.com/jsdelivr/data.jsdelivr.com/assets/1439341/ae12d237-1bdc-40ce-bd1a-6a6fe5f7dbf1)
